### PR TITLE
Release v0.0.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ This first example demonstrates rendering a URL and saving the resulting image t
 
     from phantom_snap.settings import PHANTOMJS
     from phantom_snap.phantom import PhantomJSRenderer
+    from phantom_snap.imagetools import save_image
     
     config = {
         'executable': '/usr/local/bin/phantomjs',
@@ -65,6 +66,7 @@ This example shows how to provide HTML content directly to the rendering process
 
     from phantom_snap.settings import PHANTOMJS
     from phantom_snap.phantom import PhantomJSRenderer
+    from phantom_snap.imagetools import save_image
 
     config = {
         'executable': '/usr/local/bin/phantomjs',

--- a/phantom_snap/__version__.py
+++ b/phantom_snap/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.14'
+__version__ = '0.0.15'
 VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/phantom_snap/render-ipc.js
+++ b/phantom_snap/render-ipc.js
@@ -56,6 +56,24 @@ console.error = function(msg) {
     system.stderr.writeLine(msg);
 };
 
+// From https://stackoverflow.com/a/41713002, https://jsfiddle.net/47zwb41o/
+escape = function( s ){
+    var chr, hex, i = 0, l = s.length, out = '';
+    for( ; i < l; i ++ ){
+        chr = s.charAt( i );
+        if( chr.search( /[A-Za-z0-9\@\*\_\+\-\.\/]/ ) > -1 ){
+            out += chr; continue; }
+        hex = s.charCodeAt( i ).toString( 16 );
+        out += '%' + ( hex.length % 2 != 0 ? '0' : '' ) + hex;
+    }
+    return out;
+};
+
+b64ToUtf8 = function(s){
+	s = s.replace(/\s/g, '');
+	return decodeURIComponent(escape(atob(s)));
+};
+
 renderHtml = function (request) {
 
     var page = webpage.create();
@@ -167,7 +185,7 @@ renderHtml = function (request) {
         page.setContent(request.html, request.url);
     }
     else if(request.hasOwnProperty('html64')) {
-        page.setContent(atob(request.html64), request.url);
+        page.setContent(b64ToUtf8(request.html64), request.url);
     }
     else {
         page.open(request.url);

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='phantom-snap',
         'nose>=1.3.7'
     ],
     install_requires=[
-        'eventlet>=0.21.0'
+        'eventlet>=0.23.0'
     ],
     tests_require=[
         'nose',


### PR DESCRIPTION
Now properly handles unicode when the HTML is provided directly for rendering.

**Testing**

1. [Install PhantomJS ](http://phantomjs.org/download.html)(version 2.1.1 is what we run) and update the `config['executable']` in the below script to point to your binary.
2. `virtualenv phantom-snap; source phantom-snap/bin/activate`
3. `python setup.py sdist; pip install dist/phantom-snap-0.0.15.tar.gz`
4. Paste the following into Python:
```
from phantom_snap.settings import PHANTOMJS
from phantom_snap.phantom import PhantomJSRenderer
from phantom_snap.imagetools import save_image

config = {
    'executable': '/usr/local/bin/phantomjs',
    'args': PHANTOMJS['args'] + ['--disk-cache=false', '--load-images=true']
}
r = PhantomJSRenderer(config)

url = 'http://www.a-url.com'
html = '<html><body>اشرب المزيد من ovaltine ™</body></html>'

try:
    page = r.render(url=url, html=html, img_format='PNG')
    save_image('/tmp/html-render', page)
finally:
    r.shutdown(15)


```
5. Exit the interpreter and open the resulting image. `$ open /tmp/html-render.png`
6. It should look exactly as written in the test script. Prior to this PR, the resulting render would be this: 
<img width="287" alt="screen shot 2018-05-25 at 10 04 26 am" src="https://user-images.githubusercontent.com/7338230/40548572-1832a1e4-6003-11e8-80b4-289cec438773.png">
