### PR TITLE
Improve stability of lambda implementation

### DIFF
--- a/serverless/handler.py
+++ b/serverless/handler.py
@@ -14,24 +14,6 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 logger = logging.getLogger('PhantomJSRenderer')
 logger.setLevel(logging.DEBUG)
 
-renderer = PhantomJSRenderer({
-    u'executable': './bin/phantomjs-2.1.1',
-    u'args': [
-        '--disk-cache=false',
-        '--load-images=true',
-        '--ignore-ssl-errors=true',
-        '--ssl-protocol=any',
-    ],
-    u'env': {u'TZ': os.getenv('PHANTOMJS_TIME_ZONE', 'UTC')},
-    u'timeouts': {
-        u'initial_page_load': int(os.getenv('PHANTOMJS_TIMEOUT_INITIAL', 15)),
-        u'page_load': int(os.getenv('PHANTONJS_TIMEOUT_PAGE_LOAD', 5)),
-        u'render_response': int(os.getenv('PHANTOMJS_TIMEOUT_RENDER_RESPONSE', 5)),
-        u'process_startup': int(os.getenv('PHANTOMJS_TIMEOUT_STARTUP', 10)),
-        u'resource_wait_ms': int(os.getenv('PHANTOMJS_RESOURCE_WAIT_MS', 300)),
-    },
-})
-
 def render(event, context):
     request_data = ujson.loads(event['body'])
     logger.info("Received request {}".format(request_data))
@@ -71,6 +53,25 @@ def render(event, context):
 
     # render page
     try:
+        renderer = PhantomJSRenderer({
+            u'executable': './bin/phantomjs-2.1.1',
+            u'args': [
+                '--disk-cache=true',
+                '--max-disk-cache-size=50000',
+                '--disk-cache-path=/tmp/',
+                '--load-images=true',
+                '--ignore-ssl-errors=true',
+                '--ssl-protocol=any',
+            ],
+            u'env': {u'TZ': os.getenv('PHANTOMJS_TIME_ZONE', 'UTC')},
+            u'timeouts': {
+                u'initial_page_load': int(os.getenv('PHANTOMJS_TIMEOUT_INITIAL', 20)),
+                u'page_load': int(os.getenv('PHANTONJS_TIMEOUT_PAGE_LOAD', 15)),
+                u'render_response': int(os.getenv('PHANTOMJS_TIMEOUT_RENDER_RESPONSE', 15)),
+                u'process_startup': int(os.getenv('PHANTOMJS_TIMEOUT_STARTUP', 20)),
+                u'resource_wait_ms': int(os.getenv('PHANTOMJS_RESOURCE_WAIT_MS', 300)),
+            },
+        })
         page = renderer.render(url=url,
                                html=html,
                                img_format=img_format,
@@ -81,6 +82,7 @@ def render(event, context):
                                headers=headers,
                                cookies=cookies,
                                html_encoding=html_encoding)
+        renderer.shutdown()
     except Exception as e:
         logger.error("Uncaught exception {}".format(traceback.format_exc()))
         return {

--- a/serverless/handler.py
+++ b/serverless/handler.py
@@ -83,6 +83,7 @@ def render(event, context):
                                cookies=cookies,
                                html_encoding=html_encoding)
         renderer.shutdown()
+        del renderer
     except Exception as e:
         logger.error("Uncaught exception {}".format(traceback.format_exc()))
         return {

--- a/serverless/requirements.txt
+++ b/serverless/requirements.txt
@@ -1,3 +1,3 @@
-phantom-snap==0.0.18.dev7
+phantom-snap==0.0.18
 ujson==1.35
 jsonschema==2.6.0

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -18,7 +18,7 @@ plugins:
 
 functions:
   render:
-    memorySize: 3008
+    memorySize: 512
     timeout: 30
     handler: handler.render
     events:


### PR DESCRIPTION
This has been the most stable configuration I have found so far for running phantomjs are large(r) volumes than a one or two off invocation.

Changes:
* Move the phantomjs initialization inside the function, and call `shutdown()` when done rendering
* Utilize a disk cache instead of in-memory/disabled
* Optimizes the lambda function size to reduce costs but maintain performance.

In initial testing this has reduced our long term failure rate from 12% to roughly ~5%. We now are successful at rendering 95% of the pages we throw at it, instead of 88%.

However, this does not improve upon the lambda function eventually consuming all memory available, but appears to still work properly. I do not have a solution for this at this time, but everything appears to operate normally when the function is running at 512/512MB memory consumed.