### PR TITLE
Added support for proxy per rendering request.

### DIFF
--- a/phantom_snap/decorators.py
+++ b/phantom_snap/decorators.py
@@ -47,7 +47,7 @@ class Lifetime(Renderer):
         return self.config
 
     def render(self, url, html=None, img_format='PNG', width=1280, height=1024, page_load_timeout=None, user_agent=None,
-               headers=None, cookies=None, html_encoding=u'utf-8'):
+               headers=None, cookies=None, html_encoding=u'utf-8', http_proxy=None):
 
         with self._lock:
             self._last_render_time = time.time()
@@ -58,7 +58,7 @@ class Lifetime(Renderer):
             if not self._running:
                 self._startup()
 
-            return self._delegate.render(url, html, img_format, width, height, page_load_timeout, user_agent, headers, cookies, html_encoding)
+            return self._delegate.render(url, html, img_format, width, height, page_load_timeout, user_agent, headers, cookies, html_encoding, http_proxy)
 
     def _startup(self):
 

--- a/phantom_snap/lambda_renderer.py
+++ b/phantom_snap/lambda_renderer.py
@@ -44,7 +44,7 @@ class LambdaRenderer(Renderer):
             return False
 
     def _prep_json(self, url, html, img_format, width, height, page_load_timeout,
-                   user_agent, headers, cookies, html_encoding):
+                   user_agent, headers, cookies, html_encoding, http_proxy):
         """Preps the json value to be passed to the request"""
         json_dict = {
         # non-None args
@@ -52,7 +52,7 @@ class LambdaRenderer(Renderer):
             'img_format': img_format,
             'width': width,
             'height': height,
-            'html_encoding': html_encoding,
+            'html_encoding': html_encoding
         }
 
         # args that can be None
@@ -68,6 +68,9 @@ class LambdaRenderer(Renderer):
 
         if user_agent is not None:
             json_dict['user_agent'] = user_agent
+
+        if http_proxy is not None:
+            json_dict['http_proxy'] = http_proxy
 
         if headers is not None:
             json_dict['headers'] = headers
@@ -95,7 +98,7 @@ class LambdaRenderer(Renderer):
 
     def render(self, url, html=None, img_format='PNG', width=1280, height=1024,
                page_load_timeout=None, user_agent=None,
-               headers=None, cookies=None, html_encoding=u'utf-8'):
+               headers=None, cookies=None, html_encoding=u'utf-8', http_proxy=None):
         """
         Render a URL target or HTML to an image file.
         :param url:
@@ -120,7 +123,8 @@ class LambdaRenderer(Renderer):
                                     user_agent=user_agent,
                                     headers=headers,
                                     cookies=cookies,
-                                    html_encoding=html_encoding)
+                                    html_encoding=html_encoding,
+                                    http_proxy=http_proxy)
         request_headers = self._prep_headers()
         timeout = self._prep_timeout()
 

--- a/phantom_snap/lambda_schema.py
+++ b/phantom_snap/lambda_schema.py
@@ -44,6 +44,11 @@ SCHEMA = {
                     "type": "string",
                     "minLength": 1
                 },
+                "http_proxy": {
+                    # default None
+                    "type": "string",
+                    "minLength": 1
+                },
                 "headers": {
                     # default None
                     "type": "object"

--- a/phantom_snap/phantom.py
+++ b/phantom_snap/phantom.py
@@ -54,7 +54,7 @@ class PhantomJSRenderer(Renderer):
         return self.config
 
     def render(self, url, html=None, img_format=u'PNG', width=1280, height=1024, page_load_timeout=None, user_agent=None,
-               headers=None, cookies=None, html_encoding=u'utf-8'):
+               headers=None, cookies=None, html_encoding=u'utf-8', http_proxy=None):
         """
         Render a URL target or HTML to an image file.
         :param url:
@@ -80,6 +80,9 @@ class PhantomJSRenderer(Renderer):
 
         if user_agent is not None:
             request[u'userAgent'] = user_agent
+
+        if http_proxy is not None:
+            request[u'httpProxy'] = http_proxy
 
         if headers is not None:
             request[u'headers'] = headers

--- a/phantom_snap/render-ipc.js
+++ b/phantom_snap/render-ipc.js
@@ -10,6 +10,7 @@
  *   "width": Integer, [optional]
  *   "height": Integer, [optional]
  *   "userAgent": String, [optional]
+ *   "httpProxy": String, [optional]
  *   "headers": Map<String, String>, [optional]
  *   "cookies": List<{
  *       'name'     : String, [required]
@@ -98,6 +99,22 @@ renderHtml = function (request) {
 
     if (request.hasOwnProperty('headers')) {
         page.customHeaders = request.headers;
+    }
+
+    if (request.hasOwnProperty('httpProxy')) {
+
+        // Undocumented API for proxy:
+        //
+        // Global:
+        // phantom.setProxy(host_or_IP, port, proxy_type, user_name, password);
+        // host_or_IP only this argument is required others are optional
+        // port is numeric value by default 80
+        // proxy_type can be http (default) or socks5
+        //
+        // Per page:
+        // page.setProxy("http://user:pass@proxy_ip_or_host:port/");
+
+        page.setProxy(request.httpProxy);
     }
 
     phantom.clearCookies();

--- a/phantom_snap/renderer.py
+++ b/phantom_snap/renderer.py
@@ -14,7 +14,7 @@ class Renderer(object):
 
     @abc.abstractmethod
     def render(self, url, html=None, img_format='PNG', width=1280, height=1024, page_load_timeout=None, user_agent=None,
-               headers=None, cookies=None, html_encoding=u'utf-8'):
+               headers=None, cookies=None, html_encoding=u'utf-8', http_proxy=None):
         raise NotImplementedError('Users must implement render() to use this base class')
 
     @abc.abstractmethod

--- a/phantom_snap/tests/test_decorators.py
+++ b/phantom_snap/tests/test_decorators.py
@@ -22,7 +22,7 @@ class MockRenderer(Renderer):
         return self.config
 
     def render(self, url, html=None, img_format='PNG', width=1280, height=1024, page_load_timeout=None, user_agent=None,
-               headers=None, cookies=None, html_encoding=u'utf-8'):
+               headers=None, cookies=None, html_encoding=u'utf-8', http_proxy=None):
         pass
 
     def shutdown(self, timeout=None):

--- a/phantom_snap/tests/test_lambda_renderer.py
+++ b/phantom_snap/tests/test_lambda_renderer.py
@@ -39,7 +39,8 @@ class TestLambda(TestCase):
                                        user_agent=None,
                                        headers=None,
                                        cookies=None,
-                                       html_encoding=u'utf-8'), expected)
+                                       html_encoding=u'utf-8',
+                                       http_proxy=None), expected)
 
         # test all additional params, not encoded html
         expected = {
@@ -63,7 +64,8 @@ class TestLambda(TestCase):
                                        user_agent='Mozilla',
                                        headers={'key': 'value'},
                                        cookies={'value': 'key'},
-                                       html_encoding=u'utf-8'), expected)
+                                       html_encoding=u'utf-8',
+                                       http_proxy=None), expected)
 
         # test all additional params, encoded html
         expected = {
@@ -87,7 +89,8 @@ class TestLambda(TestCase):
                                        user_agent='Mozilla',
                                        headers={'key': 'value'},
                                        cookies={'value': 'key'},
-                                       html_encoding=u'utf-8'), expected)
+                                       html_encoding=u'utf-8',
+                                       http_proxy=None), expected)
 
     def test_prep_headers(self):
         # default

--- a/phantom_snap/tests/test_phantom.py
+++ b/phantom_snap/tests/test_phantom.py
@@ -11,9 +11,9 @@ from phantom_snap.decorators import Lifetime
 from phantom_snap.imagetools import save_image
 
 
-class TestPhantomJS(TestCase):
-
-    pass
+# class TestPhantomJS(TestCase):
+#
+#     pass
 
 
 if __name__ == '__main__':
@@ -36,10 +36,15 @@ if __name__ == '__main__':
     r = PhantomJSRenderer(config)
     r = Lifetime(r)
 
-    with open('/tmp/crawl.html', 'r', encoding='utf-8', errors='replace') as content_file:
-        html = content_file.read()
+    # with open('/tmp/crawl.html', 'r', encoding='utf-8', errors='replace') as content_file:
+    #     html = content_file.read()
 
-    urls = [('http://www.some-domain.com', html)]
+    urls = [
+        'http://ip.changeip.com'
+        # ('http://www.some-domain.com', html),
+    ]
+
+    http_proxy = 'http://user:pass@ip:port'
 
     try:
         for url in urls:
@@ -49,7 +54,7 @@ if __name__ == '__main__':
                 url = url[0]
 
             print("Requesting {}".format(url))
-            page = r.render(url=url, html=html, img_format='PNG')
+            page = r.render(url=url, html=html, img_format='PNG', http_proxy=http_proxy)
             save_image('/tmp/render', page)
 
             import json

--- a/serverless/handler.py
+++ b/serverless/handler.py
@@ -45,6 +45,7 @@ def render(event, context):
     height = request_data.get('height', 1024)
     page_load_timeout = request_data.get('page_load_timeout', None)
     user_agent = request_data.get('user_agent', None)
+    http_proxy = request_data.get('http_proxy', None)
     headers = request_data.get('headers', None)
     cookies = request_data.get('cookies', None)
     html_encoding = request_data.get('html_encoding', 'utf-8')
@@ -82,7 +83,8 @@ def render(event, context):
                                user_agent=user_agent,
                                headers=headers,
                                cookies=cookies,
-                               html_encoding=html_encoding)
+                               html_encoding=html_encoding,
+                               http_proxy=http_proxy)
         renderer.shutdown()
         del renderer
     except Exception as e:


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
Adds parameter to supply a http proxy during rendering.

#### Release Note
Adds parameter to supply a http proxy during rendering.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Edit the `phantom_snap/tests/test_phantom.py` script. set the `http_proxy` variable to `None`.
2. Run the script and view the render output found at `/tmp/render.png`. The render should contain your real public IP.
3. Next, edit the `http_proxy` variable to be a valid proxy server using the format `http://user:pass@ip:port`.
4. Run the script again, observe that the render should display your proxy public IP.
